### PR TITLE
free up MMTabBarView, NSTabView, NSTabViewItems, etc. after drag-n-drop completes

### DIFF
--- a/MMTabBarView/MMTabBarView/MMTabDragAssistant.m
+++ b/MMTabBarView/MMTabBarView/MMTabDragAssistant.m
@@ -231,6 +231,11 @@ static MMTabDragAssistant *sharedDragAssistant = nil;
 
 		[self finishDragOfPasteboardItem:pasteboardItem];
     }  
+	
+	//	release pasteboard items et al since MMTabPasteboardItem retains UI objects
+	NSPasteboard *pboard = [NSPasteboard pasteboardWithName:NSDragPboard];
+	[pboard clearContents];
+    [pboard writeObjects:[NSArray arrayWithObject:[[[NSPasteboardItem alloc] init] autorelease]]];
 }
 
 #pragma mark -


### PR DESCRIPTION
...cts

MMTabPasteboardItem retains the MMTabBarView (sourceTabBar) which
prevents the object from being released. Since the MMTabBarView also
retains the NSTabView and any NSTabViewItems this quickly locks up a
number of other objects such that when the window is closed these still
remain.
