### PR TITLE
The mouseHovered state is not valid after closing a tab

### DIFF
--- a/MMTabBarView/MMTabBarView/MMRolloverButton.m
+++ b/MMTabBarView/MMTabBarView/MMRolloverButton.m
@@ -96,6 +96,10 @@
     NSPoint mouseLocation = [self convertPoint:[[self window] convertScreenToBase:[NSEvent mouseLocation]] fromView:nil];
     
     [[self cell] addTrackingAreasForView:self inRect:[self bounds] withUserInfo:nil mouseLocation:mouseLocation];   
+
+    if ([self mouse:mouseLocation inRect:[self bounds]]) {
+        [[self cell] mouseEntered:nil];
+    }
 }
 
 - (void)mouseEntered:(NSEvent *)theEvent {


### PR DESCRIPTION
When closing a tab with the close button on the tab, the next (right-side) tab will be moved to the place where the closed tab was. But the close button of the next tab is hidden, because of mouseHovered state is not valid.

"Only show close on hover" was ON.
Tested on OS X 10.8.4.
