### PR TITLE
Patch for Issue #18

### DIFF
--- a/MMTabBarView/MMTabBarView/MMTabBarView.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.m
@@ -316,7 +316,7 @@ static NSMutableDictionary *registeredStyleClasses = nil;
     else if ([window isKindOfClass:[NSPanel class]] && [NSApp isActive]) {
         windowActive = YES;
     }
-    else if (window.attachedSheet != nil) {
+    else if ([window isMainWindow]) {
         // Don't gray out the tab bar if we're displaying a sheet.
         windowActive = YES;
     }


### PR DESCRIPTION
Issue #18 TabBarView rendered as if parent window is not active if
Spotlight menu is open
