### PR TITLE
Remove calls to deprecated NSImage methods

### DIFF
--- a/MMTabBarView/MMTabBarView.xcodeproj/project.pbxproj
+++ b/MMTabBarView/MMTabBarView.xcodeproj/project.pbxproj
@@ -962,6 +962,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMTabBarView/MMTabBarView-Prefix.pch";
 				INFOPLIST_FILE = "MMTabBarView/MMTabBarView-Info.plist";
+				INSTALL_PATH = "@executable_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = framework;
 			};
@@ -978,6 +979,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMTabBarView/MMTabBarView-Prefix.pch";
 				INFOPLIST_FILE = "MMTabBarView/MMTabBarView-Info.plist";
+				INSTALL_PATH = "@executable_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = framework;
 			};

--- a/MMTabBarView/MMTabBarView.xcodeproj/project.pbxproj
+++ b/MMTabBarView/MMTabBarView.xcodeproj/project.pbxproj
@@ -962,7 +962,6 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMTabBarView/MMTabBarView-Prefix.pch";
 				INFOPLIST_FILE = "MMTabBarView/MMTabBarView-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = framework;
 			};
@@ -979,7 +978,6 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MMTabBarView/MMTabBarView-Prefix.pch";
 				INFOPLIST_FILE = "MMTabBarView/MMTabBarView-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = framework;
 			};

--- a/MMTabBarView/MMTabBarView.xcodeproj/project.pbxproj
+++ b/MMTabBarView/MMTabBarView.xcodeproj/project.pbxproj
@@ -730,7 +730,7 @@
 		06DB239C1609F5820071BDA0 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0450;
+				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = "Michael Monscheuer";
 			};
 			buildConfigurationList = 06DB239F1609F5820071BDA0 /* Build configuration list for PBXProject "MMTabBarView" */;
@@ -908,7 +908,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -935,7 +934,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;

--- a/MMTabBarView/MMTabBarView/MMTabDragAssistant.m
+++ b/MMTabBarView/MMTabBarView/MMTabDragAssistant.m
@@ -1001,7 +1001,6 @@ static MMTabDragAssistant *sharedDragAssistant = nil;
 			}
 
 			imageSize = [image size];
-			[image setScalesWhenResized:YES];
 
 			if (imageSize.width > imageSize.height) {
 				[image setSize:NSMakeSize(125, 125 * (imageSize.height / imageSize.width))];

--- a/MMTabBarView/MMTabBarView/Styles/MMAquaTabStyle.m
+++ b/MMTabBarView/MMTabBarView/Styles/MMAquaTabStyle.m
@@ -11,6 +11,10 @@
 #import "MMTabBarView.h"
 #import "NSView+MMTabBarViewExtensions.h"
 
+@interface MMAquaTabStyle (Private)
+- (NSImage *)_flipImage:(NSImage *)image;
+@end
+
 @implementation MMAquaTabStyle
 
 + (NSString *)name {
@@ -34,22 +38,19 @@
 - (void) loadImages {
 	// Aqua Tabs Images
 	aquaTabBg = [[NSImage alloc] initByReferencingFile:[[MMTabBarView bundle] pathForImageResource:@"AquaTabsBackground"]];
-	[aquaTabBg setFlipped:YES];
+  aquaTabBg = [[self _flipImage:aquaTabBg] retain];
 
 	aquaTabBgDown = [[NSImage alloc] initByReferencingFile:[[MMTabBarView bundle] pathForImageResource:@"AquaTabsDown"]];
-	[aquaTabBgDown setFlipped:YES];
+  aquaTabBgDown = [[self _flipImage:aquaTabBgDown] retain];
 
 	aquaTabBgDownGraphite = [[NSImage alloc] initByReferencingFile:[[MMTabBarView bundle] pathForImageResource:@"AquaTabsDownGraphite"]];
-	[aquaTabBgDown setFlipped:YES];
+  //aquaTabBgDownGraphite = [[self _flipImage:aquaTabBgDownGraphite] retain];
 
 	aquaTabBgDownNonKey = [[NSImage alloc] initByReferencingFile:[[MMTabBarView bundle] pathForImageResource:@"AquaTabsDownNonKey"]];
-	[aquaTabBgDown setFlipped:YES];
+  //aquaTabBgDownNonKey = [[self _flipImage:aquaTabBgDownNonKey] retain];
 
 	aquaDividerDown = [[NSImage alloc] initByReferencingFile:[[MMTabBarView bundle] pathForImageResource:@"AquaTabsSeparatorDown"]];
-	[aquaDivider setFlipped:NO];
-
 	aquaDivider = [[NSImage alloc] initByReferencingFile:[[MMTabBarView bundle] pathForImageResource:@"AquaTabsSeparator"]];
-	[aquaDivider setFlipped:NO];
 
 	aquaCloseButton = [[NSImage alloc] initByReferencingFile:[[MMTabBarView bundle] pathForImageResource:@"AquaTabClose_Front"]];
 	aquaCloseButtonDown = [[NSImage alloc] initByReferencingFile:[[MMTabBarView bundle] pathForImageResource:@"AquaTabClose_Front_Pressed"]];
@@ -123,7 +124,7 @@
 		//Draw for our whole bounds; it'll be automatically clipped to fit the appropriate drawing area
 		rect = [tabBarView bounds];
 
-		[aquaTabBg drawInRect:rect fromRect:NSMakeRect(0.0, 0.0, 1.0, 22.0) operation:NSCompositeSourceOver fraction:1.0 respectFlipped:NO hints:nil];
+		[aquaTabBg drawInRect:rect fromRect:NSMakeRect(0.0, 0.0, 1.0, 22.0) operation:NSCompositeSourceOver fraction:1.0 respectFlipped:YES hints:nil];
 	}
 }
 
@@ -305,6 +306,22 @@
 	}
 	//}
 	return self;
+}
+
+#pragma mark -
+
+- (NSImage *)_flipImage:(NSImage *)image
+{
+  NSSize imageSize = [image size];
+  NSImage *flippedImage = [[[NSImage alloc] initWithSize:imageSize] autorelease];
+
+  [flippedImage lockFocusFlipped:YES];
+
+  [image drawAtPoint:NSZeroPoint fromRect:NSMakeRect(0, 0, imageSize.width, imageSize.height) operation:NSCompositeSourceOver fraction:1.0];
+
+  [flippedImage unlockFocus];
+
+  return flippedImage;
 }
 
 @end


### PR DESCRIPTION
Hi, the new preview of XCode 6 shows deprecation warnings for certain NSImage methods that this pull request corrects.

This first one was a call to -setScalesWhenResized:, which is documented [here](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSImage_Class/DeprecationAppendix/AppendixADeprecatedAPI.html#//apple_ref/doc/uid/20000344-setScalesWhenResized_) to no longer have any actual effect since 10.6.

The second is to remove calls to -setFlipped: in the Aqua tab style. The documentation recommends using different methods to achieve the same effect. This patch uses a new private method on MMAquaTabStyle to redraw the images as flipped using [NSImage -lockFocusFlipped:YES], which is one of the documentation's recommended uses.

Please take a look at the commented out -flipImage: calls in the patch. In the original source, the images aquaTabBgDownGraphite and aquaTabBgDownNonKey were both not actually flipped – instead, aquaTabBgDown was flipped 3 times redundantly. I'm not sure what the intended actual behavior is, so this patch doesn't flip those two images which should mean that this style will look exactly the same. If the intended behavior was to flip those two images all along, the _flipImage: calls should be uncommented.