### PR TITLE
NSViewNoIntrinsicMetric fix for pre 10.11.

### DIFF
--- a/MMTabBarView Demo/MMTabBarView Demo/DemoWindowController.m
+++ b/MMTabBarView Demo/MMTabBarView Demo/DemoWindowController.m
@@ -214,7 +214,7 @@
     NSSize intrinsicTabBarContentSize = [tabBar intrinsicContentSize];
 
 	if (newOrientation == MMTabBarHorizontalOrientation) {
-        if (intrinsicTabBarContentSize.height == NSViewNoIntrinsicMetric)
+        if (intrinsicTabBarContentSize.height == NSViewNoInstrinsicMetric)
             intrinsicTabBarContentSize.height = 22;
 		tabBarFrame.size.height = [tabBar isTabBarHidden] ? 1 : intrinsicTabBarContentSize.height;
 		tabBarFrame.size.width = totalFrame.size.width;

--- a/MMTabBarView/MMTabBarView/MMTabBarView.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.m
@@ -232,7 +232,7 @@ static NSMutableDictionary *registeredStyleClasses = nil;
     if ([_style respondsToSelector:@selector(intrinsicContentSizeOfTabBarView:)])
         return [_style intrinsicContentSizeOfTabBarView:self];
 
-    return NSMakeSize(NSViewNoIntrinsicMetric, NSViewNoIntrinsicMetric);
+    return NSMakeSize(NSViewNoInstrinsicMetric, NSViewNoInstrinsicMetric);
 }
 
 #pragma mark -

--- a/MMTabBarView/MMTabBarView/Styles/Yosemite Tab Style/MMYosemiteTabStyle.m
+++ b/MMTabBarView/MMTabBarView/Styles/Yosemite Tab Style/MMYosemiteTabStyle.m
@@ -48,7 +48,7 @@ StaticImage(YosemiteTabNewPressed)
 
 - (NSSize)intrinsicContentSizeOfTabBarView:(MMTabBarView *)tabBarView
 {
-    return NSMakeSize(NSViewNoIntrinsicMetric, 25);
+    return NSMakeSize(NSViewNoInstrinsicMetric, 25);
 }
 
 - (CGFloat)leftMarginForTabBarView:(MMTabBarView *)tabBarView {


### PR DESCRIPTION
Revert to the pre-Mac OS X 10.11 version of `NSViewNoIntrinsicMetric` constant.

The correct spelling is only available on Mac OS X 10.11 and newer, so the use
of `NSViewNoInstrinsicMetric` preserves backwards compatibility.
