### PR TITLE
Fixed issue where if you turned on auto hiding, then you closed the 2nd to last tab, the tab bar would hide, BUT it wouldn't release the NSTabViewItem you just closed.

### DIFF
--- a/MMTabBarView Demo/MMTabBarView Demo/DemoWindowController.m
+++ b/MMTabBarView Demo/MMTabBarView Demo/DemoWindowController.m
@@ -458,6 +458,10 @@
 	NSLog(@"didCloseTabViewItem: %@", [tabViewItem label]);
 }
 
+- (void)tabView:(NSTabView *)aTabView didDetachTabViewItem:(NSTabViewItem *)tabViewItem {
+	NSLog(@"didDetachTabViewItem: %@", [tabViewItem label]);
+}
+
 - (void)tabView:(NSTabView *)aTabView didMoveTabViewItem:(NSTabViewItem *)tabViewItem toIndex:(NSUInteger)index
 {
     NSLog(@"tab view did move tab view item %@ to index:%ld",[tabViewItem label],index);

--- a/MMTabBarView/MMTabBarView/MMTabBarView.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.m
@@ -1520,8 +1520,10 @@ static NSMutableDictionary *registeredStyleClasses = nil;
 }
 
 - (void)update:(BOOL)animate {
-    
-        // not currently handle draggig?
+	
+	BOOL exitAfterRemovingAttachedButton = NO;
+	
+        // not currently handle dragging?
     if ([[MMTabDragAssistant sharedDragAssistant] isDragging] == NO) {
 
             // hide/show? (these return if already in desired state)
@@ -1530,7 +1532,7 @@ static NSMutableDictionary *registeredStyleClasses = nil;
         else if (!_isHidden && ![self _shouldDisplayTabBar]) {
             [self hideTabBar:YES animate:animate];
             [self setNeedsUpdate:NO];
-            return;
+            exitAfterRemovingAttachedButton = YES;
         }
     }
 
@@ -1548,6 +1550,9 @@ static NSMutableDictionary *registeredStyleClasses = nil;
 		}
 	}
 
+	if(exitAfterRemovingAttachedButton)
+		return;
+	
     BOOL isDragging = [[MMTabDragAssistant sharedDragAssistant] isDragging];
     MMAttachedTabBarButton *draggedButton = [[MMTabDragAssistant sharedDragAssistant] attachedTabBarButton];
 


### PR DESCRIPTION
If you have auto-hiding turned on for your tab bar and then you close the 2nd to the last tab, the update: method would hide the tab bar, then short-circuit and return.  This means it never actually removed the tab bar item (if you are watching allocations in Instruments, you’d see that there are still 2 NSTabViewItems that are alive).  Also, because update: was short-circuited, the delegate never got “didDetachTabViewItem” called for that tab you just closed.  

This may or may not be the best way to fix it - I’m not familiar enough with the project to know if there’s a more appropriate place to put this fix - but from my testing, it resolves the memory issue + the delegate call issue.