### PR TITLE
allow MMTabBarView to be a module for Objective-C and not for Objective-C++ plus expose NSTabBarItem extensions

### DIFF
--- a/MMTabBarView/MMTabBarView.xcodeproj/project.pbxproj
+++ b/MMTabBarView/MMTabBarView.xcodeproj/project.pbxproj
@@ -98,7 +98,7 @@
 		0634F0B2160A1B6600A6C86A /* NSString+MMTabBarViewExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0634F0B0160A1B6600A6C86A /* NSString+MMTabBarViewExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0634F0B3160A1B6600A6C86A /* NSString+MMTabBarViewExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0634F0B1160A1B6600A6C86A /* NSString+MMTabBarViewExtensions.m */; };
 		066375A216171EFC004A1128 /* MMTabBarItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 066375A116171EEF004A1128 /* MMTabBarItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		066375A516172608004A1128 /* NSTabViewItem+MMTabBarViewExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 066375A316172608004A1128 /* NSTabViewItem+MMTabBarViewExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		066375A516172608004A1128 /* NSTabViewItem+MMTabBarViewExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 066375A316172608004A1128 /* NSTabViewItem+MMTabBarViewExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		066375A616172608004A1128 /* NSTabViewItem+MMTabBarViewExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 066375A416172608004A1128 /* NSTabViewItem+MMTabBarViewExtensions.m */; };
 		066375F01617493D004A1128 /* SafariAWATClose.png in Resources */ = {isa = PBXBuildFile; fileRef = 066375BF1617493D004A1128 /* SafariAWATClose.png */; };
 		066375F11617493D004A1128 /* SafariAWATClose@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 066375C01617493D004A1128 /* SafariAWATClose@2x.png */; };

--- a/MMTabBarView/MMTabBarView/MMOverflowPopUpButton.h
+++ b/MMTabBarView/MMTabBarView/MMOverflowPopUpButton.h
@@ -6,8 +6,13 @@
 //  Copyright 2005 Positive Spin Media. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+@import QuartzCore;
+#else
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MMTabBarView/MMTabBarView/MMOverflowPopUpButtonCell.h
+++ b/MMTabBarView/MMTabBarView/MMOverflowPopUpButtonCell.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2016 Michael Monscheuer. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 #import "MMOverflowPopUpButton.h"
 

--- a/MMTabBarView/MMTabBarView/MMProgressIndicator.h
+++ b/MMTabBarView/MMTabBarView/MMProgressIndicator.h
@@ -6,7 +6,11 @@
 //  Copyright 2006 Positive Spin Media. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MMTabBarView/MMTabBarView/MMRolloverButton.h
+++ b/MMTabBarView/MMTabBarView/MMRolloverButton.h
@@ -5,7 +5,11 @@
 //  Created by Michael Monscheuer on 9/8/12.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 #import "MMRolloverButtonCell.h"
 

--- a/MMTabBarView/MMTabBarView/MMRolloverButtonCell.h
+++ b/MMTabBarView/MMTabBarView/MMRolloverButtonCell.h
@@ -5,7 +5,11 @@
 //  Created by Michael Monscheuer on 9/8/12.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MMTabBarView/MMTabBarView/MMTabBarButton.h
+++ b/MMTabBarView/MMTabBarView/MMTabBarButton.h
@@ -6,7 +6,11 @@
 //
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 #import "MMRolloverButton.h"
 

--- a/MMTabBarView/MMTabBarView/MMTabBarButtonCell.h
+++ b/MMTabBarView/MMTabBarView/MMTabBarButtonCell.h
@@ -6,7 +6,11 @@
 //
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 #import "MMRolloverButtonCell.h"
 

--- a/MMTabBarView/MMTabBarView/MMTabBarItem.h
+++ b/MMTabBarView/MMTabBarView/MMTabBarItem.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2016 Michael Monscheuer. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Foundation;
+#else
 #import <Foundation/Foundation.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MMTabBarView/MMTabBarView/MMTabBarView.h
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.h
@@ -10,7 +10,11 @@
    This view provides a control interface to manage a regular NSTabView.  It looks and works like the tabbed browsing interface of many popular browsers.
  */
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 #pragma mark Umbrella Header section
 
@@ -43,6 +47,7 @@ FOUNDATION_EXPORT const unsigned char MMTabBarViewVersionString[];
 #import <MMTabBarView/MMYosemiteTabStyle.h>
 
 #import <MMTabBarView/NSBezierPath+MMTabBarViewExtensions.h>
+#import <MMTabBarView/NSTabViewItem+MMTabBarViewExtensions.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -271,7 +276,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Add attached tab bar button for specified tab view item
  *
- *  @param tab view item to add attached tab bar button for
+ *  @param item view item to add attached tab bar button for
  */
 - (void)addAttachedButtonForTabViewItem:(NSTabViewItem *)item;
 

--- a/MMTabBarView/MMTabBarView/NSBezierPath+MMTabBarViewExtensions.h
+++ b/MMTabBarView/MMTabBarView/NSBezierPath+MMTabBarViewExtensions.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2016 Michael Monscheuer. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MMTabBarView/MMTabBarView/NSTabViewItem+MMTabBarViewExtensions.h
+++ b/MMTabBarView/MMTabBarView/NSTabViewItem+MMTabBarViewExtensions.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2016 Michael Monscheuer. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 #import "MMTabBarItem.h"
 

--- a/MMTabBarView/MMTabBarView/Styles/MMAdiumTabStyle.h
+++ b/MMTabBarView/MMTabBarView/Styles/MMAdiumTabStyle.h
@@ -6,7 +6,11 @@
 //  Copyright 2006 Kent Sutherland. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 #import "MMTabStyle.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/MMTabBarView/MMTabBarView/Styles/MMAquaTabStyle.h
+++ b/MMTabBarView/MMTabBarView/Styles/MMAquaTabStyle.h
@@ -6,7 +6,11 @@
 //  Copyright 2006 Positive Spin Media. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 #import "MMTabStyle.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/MMTabBarView/MMTabBarView/Styles/MMCardTabStyle.h
+++ b/MMTabBarView/MMTabBarView/Styles/MMCardTabStyle.h
@@ -6,7 +6,11 @@
 //
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 #import "MMTabStyle.h"
 #import "NSBezierPath+MMTabBarViewExtensions.h"
 

--- a/MMTabBarView/MMTabBarView/Styles/MMLiveChatTabStyle.h
+++ b/MMTabBarView/MMTabBarView/Styles/MMLiveChatTabStyle.h
@@ -6,7 +6,11 @@
 //  Copyright 2006 Keith Blount. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 #import "MMTabStyle.h"
 #import "NSBezierPath+MMTabBarViewExtensions.h"
 

--- a/MMTabBarView/MMTabBarView/Styles/MMMetalTabStyle.h
+++ b/MMTabBarView/MMTabBarView/Styles/MMMetalTabStyle.h
@@ -6,7 +6,11 @@
 //  Copyright 2006 Positive Spin Media. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 #import "MMTabStyle.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/MMTabBarView/MMTabBarView/Styles/MMUnifiedTabStyle.h
+++ b/MMTabBarView/MMTabBarView/Styles/MMUnifiedTabStyle.h
@@ -6,7 +6,11 @@
 //  Copyright 2006 Keith Blount. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 #import "MMTabStyle.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/MMTabBarView/MMTabBarView/Styles/Safari Tab Style/MMSafariTabStyle.h
+++ b/MMTabBarView/MMTabBarView/Styles/Safari Tab Style/MMSafariTabStyle.h
@@ -6,7 +6,11 @@
 //  Copyright 2011 Marrintech. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 #import "MMTabStyle.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/MMTabBarView/MMTabBarView/Styles/Yosemite Tab Style/MMYosemiteTabStyle.h
+++ b/MMTabBarView/MMTabBarView/Styles/Yosemite Tab Style/MMYosemiteTabStyle.h
@@ -8,7 +8,11 @@
 //  Copyright 2016 Ajin Man Tuladhar. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 #import "MMTabStyle.h"
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
- eliminate warnings on Objective-C code when not importing modules and still allow Objective-C++ code to include framework headers when modules are not available
- add NSTabViewItem+MMTabBarViewExtensions.h to umbrella header such that MMTabBarView additional properties on NSTabViewItem may be manipulated.