### PR TITLE
support macOS 10.9 with the "Mojave" tab style

### DIFF
--- a/MMTabBarView/MMTabBarView/Styles/Mojave Tab Style/MMMojaveTabStyle+Assets.m
+++ b/MMTabBarView/MMTabBarView/Styles/Mojave Tab Style/MMMojaveTabStyle+Assets.m
@@ -74,6 +74,17 @@
     return [self assets][@(mode)][@(part)] ? : [self assets][@(MMMappearanceAquaLight)][@(part)];
 }
 
+inline static NSColor* labelColor(void)
+{
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+	if ( @available(macos 10.10, *) )
+	{
+		return NSColor.labelColor;
+	}
+#endif
+	return NSColor.textColor;
+}
+
 - (NSDictionary *)assets
 {
     static NSDictionary *assets = nil;
@@ -90,7 +101,7 @@
                      @(MMMtabUnselectedHover)     : [NSColor colorWithSRGBRed:0.655 green:0.655 blue:0.655 alpha:1.0],
 
                      @(MMMtabSelectedFont)        : [NSColor textColor],
-                     @(MMMtabUnselectedFont)      : [NSColor labelColor],
+                     @(MMMtabUnselectedFont)      : labelColor(),
                      @(MMMtabUnselectedHoverFont) : [NSColor textColor],
                      
                      @(MMMtabBarBackground)       : [NSColor colorWithSRGBRed:0.710 green:0.706 blue:0.710 alpha:1.0],
@@ -146,7 +157,7 @@
                      @(MMMtabUnselectedHover)     : [NSColor colorWithSRGBRed:0.667 green:0.667 blue:0.663 alpha:1.0],
                      
                      @(MMMtabSelectedFont)        : [NSColor textColor],
-                     @(MMMtabUnselectedFont)      : [NSColor labelColor],
+                     @(MMMtabUnselectedFont)      : labelColor(),
                      @(MMMtabUnselectedHoverFont) : [NSColor textColor],
                      
                      @(MMMtabBarBackground)   : [NSColor colorWithSRGBRed:0.741 green:0.741 blue:0.741 alpha:1.0],


### PR DESCRIPTION
NSColor.labelColor is only available in macOS 10.10 and later. This change allows the "Mojave" tab style (introduced by #62) to be used back to macOS 10.9 for those applications that still require support for macOS 10.9 but want a tab style that works with macOS 10.14 DarkAqua as well.