### PR TITLE
clearer labels for macOS 10.14 Mojave DarkAqua and adjust Mojave drawing issues with NSCell

### DIFF
--- a/MMTabBarView/MMTabBarView/MMTabBarButtonCell.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarButtonCell.m
@@ -1052,7 +1052,6 @@ inline static bool useShadow(NSView* const inView) {
 	if (useShadow(controlView)) {
 		NSShadow *shadow = [[NSShadow alloc] init];
 		[shadow setShadowColor:[NSColor.whiteColor colorWithAlphaComponent:0.4]];
-		[shadow setShadowColor:[NSColor.whiteColor colorWithAlphaComponent:0.6]];
 		[shadow setShadowBlurRadius:1.0];
 		[shadow setShadowOffset:NSMakeSize(0.0, -1.0)];
 		[shadow set];

--- a/MMTabBarView/MMTabBarView/MMTabBarButtonCell.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarButtonCell.m
@@ -1036,17 +1036,27 @@ NS_ASSUME_NONNULL_BEGIN
     [icon drawInRect:iconRect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0 respectFlipped:YES hints:nil];
 }
 
+inline static bool useShadow(NSView* const inView) {
+	if (@available(macOS 10.14, *)) {
+		return ![[inView.effectiveAppearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]] isEqualToString:NSAppearanceNameDarkAqua];
+	}
+	return true;
+}
+
 - (void)_drawTitleWithFrame:(NSRect)frame inView:(NSView *)controlView {
 
     NSRect rect = [self titleRectForBounds:frame];
 
     [NSGraphicsContext saveGraphicsState];
-    
-    NSShadow *shadow = [[NSShadow alloc] init];
-    [shadow setShadowColor:[NSColor.whiteColor colorWithAlphaComponent:0.4]];
-    [shadow setShadowBlurRadius:1.0];
-    [shadow setShadowOffset:NSMakeSize(0.0, -1.0)];
-    [shadow set];
+
+	if (useShadow(controlView)) {
+		NSShadow *shadow = [[NSShadow alloc] init];
+		[shadow setShadowColor:[NSColor.whiteColor colorWithAlphaComponent:0.4]];
+		[shadow setShadowColor:[NSColor.whiteColor colorWithAlphaComponent:0.6]];
+		[shadow setShadowBlurRadius:1.0];
+		[shadow setShadowOffset:NSMakeSize(0.0, -1.0)];
+		[shadow set];
+	}
 
     // draw title
     [self.attributedStringValue drawInRect:rect];

--- a/MMTabBarView/MMTabBarView/Styles/Safari Tab Style/MMSafariTabStyle.m
+++ b/MMTabBarView/MMTabBarView/Styles/Safari Tab Style/MMSafariTabStyle.m
@@ -367,6 +367,9 @@ StaticImage(SafariIWITRightCap)
 
 -(void)drawBezelOfTabCell:(MMTabBarButtonCell *)cell withFrame:(NSRect)frame inView:(NSView *)controlView {
 
+	if (@available(macos 10.14, *)) {
+		return;
+	}
     if (cell.controlView.frame.size.height < 2)
         return;
 
@@ -376,9 +379,6 @@ StaticImage(SafariIWITRightCap)
     NSRect cellFrame = frame;
     
     cellFrame = NSInsetRect(cellFrame, -5.0, 0);
-    
-    if (cell.controlView.frame.size.height < 2)
-        return;
 
     NSImage *left = nil;
     NSImage *center = nil;


### PR DESCRIPTION
Labels in the tabs are drawn using a drop shadow which looks nice for Aqua; however, in DarkAqua the shadow makes the text look blurry as it is a white color blended with the background. For macOS 10.14 Mojave in DarkAqua the drop shadow is no longer shown.

NSCell was deprecated in macOS 10.10 Yosemite. For reason I do not fully understand MMTabBarView draws the tab view in both the view code and the cell code; however, in Mojave this can cause problems. As the NSCell drawing implementation is redundant it is disabled in macOS 10.14 Mojave to prevent anomalous drawing with the wrong appearance.