### PR TITLE
Use 'secondary label color' for unselected tab font in Mojave dark mode

### DIFF
--- a/MMTabBarView/MMTabBarView/Styles/Mojave Tab Style/MMMojaveTabStyle+Assets.m
+++ b/MMTabBarView/MMTabBarView/Styles/Mojave Tab Style/MMMojaveTabStyle+Assets.m
@@ -83,6 +83,17 @@ inline static NSColor* labelColor(void)
 	return NSColor.textColor;
 }
 
+inline static NSColor* secondaryLabelColor(void)
+{
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+	if ( @available(macos 10.10, *) )
+	{
+		return NSColor.secondaryLabelColor;
+	}
+#endif
+	return NSColor.selectedTextBackgroundColor;
+}
+
 - (NSDictionary<NSNumber*, NSDictionary<NSNumber*, id>*> *)assets
 {
     static NSDictionary<NSNumber*, NSDictionary<NSNumber*, id>*> *assets = nil;
@@ -211,8 +222,8 @@ inline static NSColor* labelColor(void)
                      @(MMMtabUnselectedHover)     : [NSColor colorWithSRGBRed:0.110 green:0.110 blue:0.110 alpha:1.0],
 
                      @(MMMtabSelectedFont)        : NSColor.textColor,
-                     @(MMMtabUnselectedFont)      : NSColor.selectedTextBackgroundColor,
-                     @(MMMtabUnselectedHoverFont) : NSColor.selectedTextBackgroundColor,
+                     @(MMMtabUnselectedFont)      : secondaryLabelColor(),
+                     @(MMMtabUnselectedHoverFont) : secondaryLabelColor(),
                      
                      @(MMMtabBarBackground)   : [NSColor colorWithSRGBRed:0.112 green:0.112 blue:0.112 alpha:1.0],
 
@@ -267,8 +278,8 @@ inline static NSColor* labelColor(void)
                      @(MMMtabUnselectedHover)     : [NSColor colorWithSRGBRed:0.110 green:0.110 blue:0.110 alpha:1.0],
 
                      @(MMMtabSelectedFont)        : NSColor.textColor,
-                     @(MMMtabUnselectedFont)      : NSColor.selectedTextBackgroundColor,
-                     @(MMMtabUnselectedHoverFont) : NSColor.selectedTextBackgroundColor,
+                     @(MMMtabUnselectedFont)      : secondaryLabelColor(),
+                     @(MMMtabUnselectedHoverFont) : secondaryLabelColor(),
                      
 					 @(MMMtabBarBackground)   : [NSColor colorWithSRGBRed:0.112 green:0.112 blue:0.112 alpha:1.0],
 


### PR DESCRIPTION
Currently, the text of unselected tabs in dark mode is deep blue, which is the *background* color of selected texts, as in the tabs Bar and View below.
![mmtabbar-1 - Edited](https://user-images.githubusercontent.com/1910898/71551342-1f548280-29ab-11ea-886d-11aaef16e747.png)

This pull request proposes to change the color to gray, differentiating the text color from the background more. It is the secondary label color in NSColor.
![mmtabbar-0 - Edited](https://user-images.githubusercontent.com/1910898/71551344-254a6380-29ab-11ea-9759-fda17e70c31e.png)
