### PR TITLE
In commit 9e03810415250ed7e55cc8576a6373c1f1d22bf3, I changed…

### DIFF
--- a/MMTabBarView/MMTabBarView/MMTabBarView.h
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.h
@@ -88,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Delegate
  */
-@property (weak)   IBOutlet id <MMTabBarViewDelegate> delegate;
+@property (nullable, strong)   IBOutlet id <MMTabBarViewDelegate> delegate;
 
 #pragma mark Working with View's current state
 

--- a/MMTabBarView/MMTabBarView/MMTabBarView.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.m
@@ -100,7 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL                            _needsUpdate;
 
     // delegate
-    id <MMTabBarViewDelegate> __weak _delegate;
+    id <MMTabBarViewDelegate>       _delegate;
 }
 
 static NSMutableDictionary<NSString*, Class <MMTabStyle>> *registeredStyleClasses = nil;


### PR DESCRIPTION
…the imp lementation of the delegate property to match the "weak" declaration. This was breaking the demo app, so I now revert the implementation to "strong", and change the declaration so it matches the implementation. Note the the client app should make sure that the delegate does not have a strong reference to MMTabBarView, or there will be a retain cycle.