### PR TITLE
Fix problem of assigned controlView being optimised away in XCode 12 …

### DIFF
--- a/MMTabBarView/MMTabBarView.xcodeproj/project.pbxproj
+++ b/MMTabBarView/MMTabBarView.xcodeproj/project.pbxproj
@@ -839,6 +839,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 06DB239A1609F5820071BDA0;

--- a/MMTabBarView/MMTabBarView/MMAttachedTabBarButtonCell.h
+++ b/MMTabBarView/MMTabBarView/MMAttachedTabBarButtonCell.h
@@ -18,13 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  The control view
- * 
- *  TODO: fix, rename "attachedTabBarButton"
  */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wincompatible-property-type"
-@property (assign) MMAttachedTabBarButton *controlView;
-#pragma clang diagnostic pop
+@property (nullable, weak) MMAttachedTabBarButton *attachedTabBarButton;
 
 @end
 

--- a/MMTabBarView/MMTabBarView/MMAttachedTabBarButtonCell.m
+++ b/MMTabBarView/MMTabBarView/MMAttachedTabBarButtonCell.m
@@ -24,12 +24,15 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark -
 #pragma mark Properties
 
-- (MMAttachedTabBarButton *)controlView {
-    return (MMAttachedTabBarButton *)[super controlView];
+- (nullable MMAttachedTabBarButton *)controlView {
+    // return (MMAttachedTabBarButton *)[super controlView];
+  return _attachedTabBarButton;
 }
 
-- (void)setControlView:(MMAttachedTabBarButton *)aView {
-    [super setControlView:aView];
+- (void) setControlView:(nullable NSView *)aView
+{
+  [super setControlView:aView];
+  _attachedTabBarButton = (MMAttachedTabBarButton*)aView;
 }
 
 #pragma mark -

--- a/MMTabBarView/MMTabBarView/MMTabBarButtonCell.h
+++ b/MMTabBarView/MMTabBarView/MMTabBarButtonCell.h
@@ -36,18 +36,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  The control view
- * 
- *  TODO: fix, rename "tabBarButton"
  */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wincompatible-property-type"
-@property (assign) MMTabBarButton *controlView;
-#pragma clang diagnostic pop
+@property (nullable, weak) MMTabBarButton *tabBarButton;
 
 /**
  *  Tab bar view the tab bar button belongs to
  */
-@property (readonly) MMTabBarView *tabBarView;
+@property (nullable, readonly) MMTabBarView *tabBarView;
 
 #pragma mark Update images
 
@@ -118,14 +113,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Get progress indicator
  */
-@property (readonly) MMProgressIndicator *indicator;
+@property (nullable, readonly) MMProgressIndicator *indicator;
 
 #pragma mark Close Button Support
 
 /**
  *  The close button
  */
-@property (readonly) MMRolloverButton *closeButton;
+@property (nullable, readonly) MMRolloverButton *closeButton;
 
 /**
  *  Check if receiver should display close button

--- a/MMTabBarView/MMTabBarView/MMTabBarButtonCell.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarButtonCell.m
@@ -53,16 +53,18 @@ NS_ASSUME_NONNULL_BEGIN
 	return self;
 }
 
-- (MMTabBarButton *)controlView {
-    return (MMTabBarButton *)[super controlView];
+- (nullable MMTabBarButton *)controlView {
+    // return (MMTabBarButton *)[super controlView];
+  return _tabBarButton;
 }
 
-- (void)setControlView:(MMTabBarButton *)aView {
-    [super setControlView:aView];
+- (void)setControlView:(nullable NSView *)aView {
+  _tabBarButton = (MMTabBarButton*) aView;
+  [super setControlView:aView];
 }
 
-- (MMTabBarView *)tabBarView {
-    return self.controlView.tabBarView;
+- (nullable MMTabBarView *)tabBarView {
+    return _tabBarButton.tabBarView;
 }
 
 - (void)calcDrawInfo:(NSRect)aRect {
@@ -183,15 +185,15 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark -
 #pragma mark Progress Indicator Support
 
-- (MMProgressIndicator *)indicator {
-    return self.controlView.indicator;
+- (nullable MMProgressIndicator *)indicator {
+    return self.tabBarButton.indicator;
 }
 
 #pragma mark -
 #pragma mark Close Button Support
 
-- (MMRolloverButton *)closeButton {
-    return self.controlView.closeButton;
+- (nullable MMRolloverButton *)closeButton {
+    return self.tabBarButton.closeButton;
 }
 
 - (NSImage *)closeButtonImageOfType:(MMCloseButtonImageType)type {
@@ -599,7 +601,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)_updateCloseButton {
 
     MMTabBarView *tabBarView = self.tabBarView;
-    MMTabBarButton *button = self.controlView;
+    MMTabBarButton *button = self.tabBarButton;
     MMRolloverButton *closeButton = button.closeButton;
 
     [self _updateCloseButtonImages];
@@ -630,7 +632,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)_updateIndicator {
 
     MMTabBarView *tabBarView = self.tabBarView;
-    MMTabBarButton *button = self.controlView;
+    MMTabBarButton *button = self.tabBarButton;
     MMProgressIndicator *indicator = button.indicator;
 
         // adjust visibility and position of process indicator

--- a/MMTabBarView/MMTabBarView/Styles/Mojave Tab Style/MMMojaveTabStyle.m
+++ b/MMTabBarView/MMTabBarView/Styles/Mojave Tab Style/MMMojaveTabStyle.m
@@ -161,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 	 // Figure out correct text color
     
-    if ( cell.controlView.state == NSOnState )
+    if ( cell.tabBarButton.state == NSOnState )
     {
         textColor = [self colorForPart:MMMtabSelectedFont ofTabBarView:cell.tabBarView];
     }


### PR DESCRIPTION
Using Xcode 12, on a release build which uses -Os, MMTabBarView was crashing in some circumstances after creating a tab.

Enabling Zombie detection, I could see it complained about an MMAttachedTabBarButton being released.  The problem went away if using -O0 (Add "GCC_OPTIMIZATION_LEVEL = 0" to Release.xcconfig).

The existing code overloaded NSCell controlView with different types. There were compiler warnings about this recommending unsafe retain, so I think the ARC compiler somehow optimised the memory management for these badly.

There was also comments by these properties saying "TODO: fix, rename".  So I went ahead and renamed them and updated the controlView accessor methods.  There was also some fiddling about with nullable to keep the compiler happy.

Xcode 12 still gives a load of warnings:  
```
Use of '@import' in framework header is discouraged, including this header requires -fmodules
```
and a linker warning:
```
ld: warning: dylib (/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/12.0.0/lib/darwin/libclang_rt.ubsan_osx_dynamic.dylib) was built for newer macOS version (10.10) than being linked (10.9)
```
but those are something to fix another day.