### PR TITLE
tabView:willMoveTabViewItem:toIndex: added to MMTabBarViewDelegate

### DIFF
--- a/MMTabBarView/MMTabBarView/MMTabBarView.h
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.h
@@ -614,6 +614,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)tabView:(NSTabView *)aTabView willCloseTabViewItem:(NSTabViewItem *)tabViewItem;
 - (void)tabView:(NSTabView *)aTabView didCloseTabViewItem:(NSTabViewItem *)tabViewItem;
 - (void)tabView:(NSTabView *)aTabView didDetachTabViewItem:(NSTabViewItem *)tabViewItem;
+- (void)tabView:(NSTabView *)aTabView willMoveTabViewItem:(NSTabViewItem *)tabViewItem toIndex:(NSUInteger)index;
 - (void)tabView:(NSTabView *)aTabView didMoveTabViewItem:(NSTabViewItem *)tabViewItem toIndex:(NSUInteger)index;
 
     // Informal tab bar visibility methods

--- a/MMTabBarView/MMTabBarView/MMTabBarView.m
+++ b/MMTabBarView/MMTabBarView/MMTabBarView.m
@@ -434,6 +434,9 @@ static NSMutableDictionary<NSString*, Class <MMTabStyle>> *registeredStyleClasse
 
 - (void)moveTabViewItem:(NSTabViewItem *)anItem toIndex:(NSUInteger)index {
 
+    if (_delegate && [_delegate respondsToSelector:@selector(tabView:willMoveTabViewItem:toIndex:)])
+        [_delegate tabView:_tabView willMoveTabViewItem:anItem toIndex:index];
+    
     [self setIsReorderingTabViewItems:YES];
     
     [_tabView removeTabViewItem:anItem];


### PR DESCRIPTION
This PR adds a message into MMTabBarViewDelegate called when a tab starts moving. It is important, because during this move operation the tab is removed and added in its new place. That means that for a moment the active tab changes and this in turn triggers tabView:didSelectTabViewItem: from NSTabViewDelegate. Not being able to detect that we are 'just' moving in the implementation of that message is a drewback that this PR is fixing. 