### PR TITLE
Fix Issue #82 - Crash hovering over close button on MacOS 12.3

### DIFF
--- a/MMTabBarView/MMTabBarView/MMRolloverButtonCell.m
+++ b/MMTabBarView/MMTabBarView/MMRolloverButtonCell.m
@@ -102,7 +102,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)mouseExited:(NSEvent *)event {
     _mouseHovered = NO;
-    [(NSControl *)self.controlView updateCell:self];
+    // Call this later or else MacOS 12.3 throws exception
+    [self.controlView performSelectorOnMainThread:@selector(updateCell:) withObject:self waitUntilDone:NO];
 }
 
 #pragma mark -


### PR DESCRIPTION
Call updateCell in next message loop to prevent exception in MacOS 12.3 when hovering over close button if onlyShowCloseOnHover is set to YES. Fixes Issue #82 